### PR TITLE
prepare for a 2.0.0

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   GEM_NAME: dry-cli-completion
-  RUBY_VERSION: 3.1.2
+  RUBY_VERSION: 4.0.2
   VERSION: ${{github.event.release.tag_name}}
 
 jobs:

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -14,8 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.7.6'
-          - '3.1.2'
+          - '3.3.9'
+          - '3.4.9'
+          - '4.0.2'
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.tool-versions
 
 # rspec failure tracking
 .rspec_status

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,6 @@ inherit_gem:
   standard: config/base.yml
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.4
   Exclude:
     - 'vendor/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,6 @@ inherit_gem:
   standard: config/base.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.3
   Exclude:
     - 'vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,21 @@
 
 ## 2.0.0
 
-- Drop support for Ruby < 3.3 (EOL)
+**Breaking change**:
+
+  - Drop support for Ruby < 3.3 (EOL)
+
+**Fixes**:
+
+- Fix missing runtime requirements
+
+**Chore**:
+
 - Better dependency requirements: Gemfile groups, version requirement, missing requirement in gemspec
+
+**Maintenance**:
+
+- Update dependencies
 
 ## 1.0.0 Inital release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CHANGELOG
+
+## 2.0.0
+
+- Drop support for Ruby < 3.3 (EOL)
+- Better dependency requirements: Gemfile groups, version requirement, missing requirement in gemspec
+
 ## 1.0.0 Inital release
 
 ## 1.0.0-beta Add support for subcommands

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,4 +1,4 @@
-FROM ruby:2.7-slim
+FROM ruby:3.4-slim
 
 RUN set -ex \
     && apt update \

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,13 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in dry-cli-completion.gemspec
 gemspec
 
-gem "rspec"
-gem "standard"
-gem "dry-cli"
-gem "pry"
+group :runtime do
+  gem 'completely', '~> 0.7'
+  gem 'dry-cli', '~> 1.4'
+end
+
+group :development do
+  gem 'pry', '~> 0.16'
+  gem 'rspec', '~> 3.13'
+  gem 'standard', '~> 1.54'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in dry-cli-completion.gemspec
 gemspec
 
-group :runtime do
-  gem "completely", "~> 0.7"
-  gem "dry-cli", "~> 1.4"
-end
-
 group :development do
   gem "pry", "~> 0.16"
   gem "rspec", "~> 3.13"

--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,12 @@ source "https://rubygems.org"
 gemspec
 
 group :runtime do
-  gem 'completely', '~> 0.7'
-  gem 'dry-cli', '~> 1.4'
+  gem "completely", "~> 0.7"
+  gem "dry-cli", "~> 1.4"
 end
 
 group :development do
-  gem 'pry', '~> 0.16'
-  gem 'rspec', '~> 3.13'
-  gem 'standard', '~> 1.54'
+  gem "pry", "~> 0.16"
+  gem "rspec", "~> 3.13"
+  gem "standard", "~> 1.54"
 end

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ See GitHub actions in `.github` for more.
 
 This library officially supports the following Ruby versions:
 
-* MRI `>= 2.7.0`
+* MRI `>= 3.3.0`
 
 ## License
 

--- a/dry-cli-completion.gemspec
+++ b/dry-cli-completion.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.3.0"
 
-  spec.add_dependency "completely", "~> 0.5"
+  spec.add_dependency "completely", "~> 0.7"
   spec.add_dependency "dry-cli", "~> 1.4"
 end

--- a/dry-cli-completion.gemspec
+++ b/dry-cli-completion.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.3.0"
 
   spec.add_dependency "completely", "~> 0.5"
-  spec.add_dependency 'dry-cli', '~> 1.4'
+  spec.add_dependency "dry-cli", "~> 1.4"
 end

--- a/dry-cli-completion.gemspec
+++ b/dry-cli-completion.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*"] + %w[Gemfile LICENSE README.md CHANGELOG.md dry-cli-completion.gemspec]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.6"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.add_dependency "completely", "~> 0.5"
+  spec.add_dependency 'dry-cli', '~> 1.4'
 end

--- a/lib/dry/cli/completion/command.rb
+++ b/lib/dry/cli/completion/command.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "dry/cli"
+
 module Dry
   class CLI
     module Completion

--- a/lib/dry/cli/completion/generator.rb
+++ b/lib/dry/cli/completion/generator.rb
@@ -2,6 +2,7 @@
 
 require "completely"
 require "stringio"
+require "dry/cli/program_name"
 
 module Dry
   class CLI

--- a/lib/dry/cli/completion/generator.rb
+++ b/lib/dry/cli/completion/generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "completely"
+require "stringio"
 
 module Dry
   class CLI

--- a/lib/dry/cli/completion/version.rb
+++ b/lib/dry/cli/completion/version.rb
@@ -3,7 +3,7 @@
 module Dry
   class CLI
     module Completion
-      VERSION = "1.0.0"
+      VERSION = "2.0.0"
     end
   end
 end

--- a/spec/dry/cli/command_spec.rb
+++ b/spec/dry/cli/command_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dry::CLI::Completion::Command do
     let(:arguments) { %w[completion] }
 
     it "raises error" do
-      expect { subject }.to raise_error(ArgumentError, "missing keyword: :shell")
+      expect { subject }.to raise_error(SystemExit)
     end
   end
 end

--- a/spec/dry/cli/generator/shell_bash_with_alias_spec.rb
+++ b/spec/dry/cli/generator/shell_bash_with_alias_spec.rb
@@ -14,8 +14,13 @@ RSpec.describe Dry::CLI::Completion::Generator do
     is_expected.to include <<~SCRIPT
       _rspec_completions() {
         local cur=${COMP_WORDS[COMP_CWORD]}
-        local compwords=("${COMP_WORDS[@]:1:$COMP_CWORD-1}")
+        local compwords=()
+        if ((COMP_CWORD > 0)); then
+          compwords=("${COMP_WORDS[@]:1:$((COMP_CWORD - 1))}")
+        fi
         local compline="${compwords[*]}"
+
+        COMPREPLY=()
 
         case "$compline" in
           'completion'*'bash')
@@ -42,12 +47,12 @@ RSpec.describe Dry::CLI::Completion::Generator do
             while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
-          'generate'*)
-            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "config test")" -- "$cur")
-            ;;
-
           'g config'*)
             while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help --apps")" -- "$cur")
+            ;;
+
+          'generate'*)
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "config test")" -- "$cur")
             ;;
 
           'version'*)
@@ -62,7 +67,7 @@ RSpec.describe Dry::CLI::Completion::Generator do
             while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
-          'echo'*)
+          'exec'*)
             while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
@@ -70,7 +75,7 @@ RSpec.describe Dry::CLI::Completion::Generator do
             while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help --graceful")" -- "$cur")
             ;;
 
-          'exec'*)
+          'echo'*)
             while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
@@ -92,7 +97,7 @@ RSpec.describe Dry::CLI::Completion::Generator do
 
         esac
       } &&
-      complete -F _rspec_completions rspec
+        complete -F _rspec_completions rspec
 
       # ex: filetype=sh
     SCRIPT

--- a/spec/dry/cli/generator/shell_bash_with_alias_spec.rb
+++ b/spec/dry/cli/generator/shell_bash_with_alias_spec.rb
@@ -19,75 +19,75 @@ RSpec.describe Dry::CLI::Completion::Generator do
 
         case "$compline" in
           'completion'*'bash')
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help --include_aliases -a")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help --include_aliases -a")" -- "$cur")
             ;;
 
           'generate config'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help --apps")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help --apps")" -- "$cur")
             ;;
 
           'completion'*'zsh')
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help --include_aliases -a")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help --include_aliases -a")" -- "$cur")
             ;;
 
           'generate test'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help --framework")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help --framework")" -- "$cur")
             ;;
 
           'completion'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "bash zsh --help --include_aliases -a")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "bash zsh --help --include_aliases -a")" -- "$cur")
             ;;
 
           '--version'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
           'generate'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "config test")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "config test")" -- "$cur")
             ;;
 
           'g config'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help --apps")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help --apps")" -- "$cur")
             ;;
 
           'version'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
           'g test'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help --framework")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help --framework")" -- "$cur")
             ;;
 
           'start'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
           'echo'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
           'stop'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help --graceful")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help --graceful")" -- "$cur")
             ;;
 
           'exec'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
           '-v'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
           'v'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "--help")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "--help")" -- "$cur")
             ;;
 
           'g'*)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "config test")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "config test")" -- "$cur")
             ;;
 
           *)
-            while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_rspec_completions_filter "version echo start stop exec completion generate v -v --version g help")" -- "$cur" )
+            while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_rspec_completions_filter "version echo start stop exec completion generate v -v --version g help")" -- "$cur")
             ;;
 
         esac

--- a/spec/foo-cli
+++ b/spec/foo-cli
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require_relative "./foo"
+require_relative "foo"
 
 Dry::CLI.new(Foo::CLI::Commands).call


### PR DESCRIPTION
Changes in this PR: see [CHANGELOG.md](https://github.com/rngtng/dry-cli-completion/pull/9/changes#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)

The gem was not working because of missing requirements I added in the code 7b48a124823eab5590d7b15065ca7cbd892cf6d4 & in Gemfile & gemspec 48b8f8141de1bbca7b6f0ee0f628e8b27bc6f315. The other commits are documentation, linting, cleaning & updating the requirements.

Linting check is good, but there are 2 rspec failing I have not been able to fix myself:

1. the expected error message when no shell is specified on the completion command is not the triggering, but I don't know how to fix that
2. the bash completion with aliases has not the expected content but I guess that's due to completely version been updated